### PR TITLE
Log persistent CSV of device requests and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cache.ics
 
 test/test_*.png
+test/test.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ cache.ics
 test/test_*.png
 test/test.csv
 
+persist/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Project-specific
 cache.ics
 
-test/test_*.png
-test/test.csv
+test/test*.png
+test/test*.csv
 
 persist/
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This can be run directly (`flask run --port 80 --host 0.0.0.0`) or in the includ
 If run directly, the device configurations (mapping device MAC to ical) are loaded from the `config` folder.
 If run in Docker, a folder including `config.json` (and any other supporting files, like custom templates) must be mounted to `/usr/app/config` in the container.
 The config schema is listed as a pydantic model in `app.py`.
+
+The `persist` directory can also be mounted so logged data is visible externally.

--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ class DeviceRecord(BaseModel):
 
 class ServerConfig(BaseModel):
   devices: Dict[str, DeviceRecord]
-  admin_password: Optional[str] = ""  # None or empty means admin functionality disabled
+  admin_password: Optional[str] = None  # None or empty means admin functionality disabled
 
 
 kConfigFilename = pathlib.Path('config/config.json')

--- a/app.py
+++ b/app.py
@@ -44,8 +44,7 @@ kConfigFilename = pathlib.Path('config/config.json')
 try:
   with open(kConfigFilename) as f:
     config = ServerConfig.model_validate_json(f.read())
-except ValidationError as e:
-  # load old-style config
+except ValidationError as e:  # load old-style config
   class DeviceMap(RootModel):
     root: Dict[str, DeviceRecord]
   with open(kConfigFilename) as f:

--- a/app.py
+++ b/app.py
@@ -1,11 +1,12 @@
+import os
 from typing import NamedTuple, Dict, Set
 
 from datetime import datetime, timedelta
 from dateutil import parser  # type: ignore
 import pytz  # type: ignore
 from typing import Optional
-from flask import Flask, jsonify, send_file, request, abort
-from pydantic import BaseModel, RootModel
+from flask import Flask, jsonify, send_file, request, abort, Response
+from pydantic import BaseModel, RootModel, ValidationError
 import io
 from urllib.request import urlopen
 import icalendar
@@ -13,6 +14,7 @@ from apscheduler.schedulers.background import BackgroundScheduler  # type: ignor
 import pathlib
 import recurring_ical_events  # type: ignore
 
+from csv_logger import CsvLogger
 from render import render as label_render, next_update
 
 import logging
@@ -33,18 +35,35 @@ class DeviceRecord(BaseModel):
   show_hours: bool = False  # whether to display hours
 
 
-class DeviceMap(RootModel):
-  root: Dict[str, DeviceRecord]
+class ServerConfig(BaseModel):
+  devices: Dict[str, DeviceRecord]
+  admin_password: Optional[str] = ""  # None or empty means admin functionality disabled
 
 
 kConfigFilename = pathlib.Path('config/config.json')
-with open(kConfigFilename) as f:
-  devices = DeviceMap.model_validate_json(f.read())
-app.logger.info(f"Loaded device map: {devices}")
+try:
+  with open(kConfigFilename) as f:
+    config = ServerConfig.model_validate_json(f.read())
+except ValidationError as e:
+  # load old-style config
+  class DeviceMap(RootModel):
+    root: Dict[str, DeviceRecord]
+  with open(kConfigFilename) as f:
+    devices_map = DeviceMap.model_validate_json(f.read())
+  config = ServerConfig(devices=devices_map.root)
+app.logger.info(f"Loaded config: {config}")
 
 kHolidaysUrl = 'https://calendar.google.com/calendar/ical/en.usa%23holiday%40group.v.calendar.google.com/public/basic.ics'
 kTimezone = pytz.timezone('America/Los_Angeles')
 kCacheValidTime = timedelta(minutes=10)  # cache is stale after this time
+
+
+PERSIST_DIR = "persist"
+os.makedirs(PERSIST_DIR, exist_ok=True)
+
+CSV_FILENAME = f"{PERSIST_DIR}/log.csv"
+meta_csv = CsvLogger(CSV_FILENAME, ['timestamp', 'mac', 'vbat', 'fwVer', 'boot', 'rst', 'part', 'rssi',
+                                    'lastDisplayTime'])
 
 
 def filter_holiday_events(events: list[icalendar.Event]) -> list[icalendar.Event]:
@@ -94,7 +113,7 @@ def schedule_cache(url: str, title: str):
                     id=url, replace_existing=True)
 
 
-for mac, device in devices.root.items():
+for mac, device in config.devices.items():
   scheduler.add_job(func=schedule_cache, args=[device.ical_url, device.title],
                     trigger="date", run_date=datetime.now() + timedelta(seconds=3),
                     id=device.ical_url, replace_existing=True)
@@ -108,12 +127,12 @@ class MetaResponse(BaseModel):
 
 
 @app.route("/version", methods=['GET'])
-def version():
-  return "0.3"
+def version() -> str:
+  return "0.4"
 
 
 @app.route("/image", methods=['GET'])
-def image():
+def image() -> Response:
   try:
     starttime = datetime.now(kTimezone)
 
@@ -124,7 +143,7 @@ def image():
       if not rendertime.tzinfo:
         rendertime = rendertime.astimezone(kTimezone)
 
-    device = devices.root[request.args.get('mac', default='')]
+    device = config.devices[request.args.get('mac', default='')]
     all_cals = [get_cached_ical(device.ical_url)]
     holiday_events = filter_holiday_events(
       recurring_ical_events.of(get_cached_ical(kHolidaysUrl)).between(rendertime, rendertime + timedelta(days=2))
@@ -145,9 +164,13 @@ def image():
 
 
 @app.route("/meta", methods=['GET'])
-def meta():
+def meta() -> Response:
   try:
     starttime = datetime.now(kTimezone)
+
+    log_data = request.args.copy()
+    log_data['timestamp'] = starttime.timestamp()
+    meta_csv.log(log_data)
 
     rendertime = starttime
     force_time = request.args.get('forceTime', default=None)
@@ -157,7 +180,7 @@ def meta():
         rendertime = rendertime.astimezone(kTimezone)
 
     device_mac = request.args.get('mac', default='')
-    device = devices.root[device_mac]
+    device = config.devices[device_mac]
     title_printable = device.title.split('\n')[0]
     ical_data = get_cached_ical(device.ical_url)
     nexttime = next_update(ical_data, device.title, device.show_hours, rendertime)
@@ -191,10 +214,10 @@ def meta():
 
 
 @app.route("/ota", methods=['GET'])
-def ota():
+def ota() -> Response:
   try:
     device_mac = request.args.get('mac', default='')
-    device = devices.root[device_mac]
+    device = config.devices[device_mac]
     ota_done_devices.add(device_mac)
     title_printable = device.title.split('\n')[0]
     assert device.ota_filename is not None
@@ -206,3 +229,11 @@ def ota():
   except Exception as e:
     app.logger.exception(f"ota: exception: {repr(e)}")
     abort(400)
+
+
+@app.route("/admin/meta_csv", methods=['GET'])
+def admin_meta_csv() -> Response:
+  if not config.admin_password or request.args.get('password', default=None) != config.admin_password:
+    abort(403)
+  file_io = io.BytesIO(meta_csv.read().encode('utf-8'))
+  return send_file(file_io, mimetype='text/csv')

--- a/config/config.json
+++ b/config/config.json
@@ -1,8 +1,11 @@
 {
-  "ecda3b46254c": {
-    "notes": "v1.1-1, 13.3 dev",
-    "title": "TESLA ROOM\nRoom 53-125 ENGR IV",
-    "ical_url": "https://calendar.google.com/calendar/ical/ogo00tv2chnq8m02539314helg@group.calendar.google.com/public/basic.ics",
-    "template_filename": "../template_1330c_mininext.svg"
-  }
+  "devices": {
+    "ecda3b46254c": {
+      "notes": "v1.1-1, 13.3 dev",
+      "title": "TESLA ROOM\nRoom 53-125 ENGR IV",
+      "ical_url": "https://calendar.google.com/calendar/ical/ogo00tv2chnq8m02539314helg@group.calendar.google.com/public/basic.ics",
+      "template_filename": "../template_1330c_mininext.svg"
+    }
+  },
+  "admin_password": null
 }

--- a/config/config_old.json
+++ b/config/config_old.json
@@ -1,0 +1,8 @@
+{
+  "ecda3b46254c": {
+    "notes": "v1.1-1, 13.3 dev",
+    "title": "TESLA ROOM\nRoom 53-125 ENGR IV",
+    "ical_url": "https://calendar.google.com/calendar/ical/ogo00tv2chnq8m02539314helg@group.calendar.google.com/public/basic.ics",
+    "template_filename": "../template_1330c_mininext.svg"
+  }
+}

--- a/csv_logger.py
+++ b/csv_logger.py
@@ -36,3 +36,10 @@ class CsvLogger:
         logger.warn(f"missing fields in file: {missing_fields}")
       dictwriter = csv.DictWriter(f, fieldnames=fieldnames, extrasaction='ignore')
       dictwriter.writerow(data)
+
+  def read(self) -> str:
+    if not os.path.exists(self._filename):
+      return ""
+
+    with open(self._filename, 'r') as f:
+      return f.read()

--- a/csv_logger.py
+++ b/csv_logger.py
@@ -25,7 +25,10 @@ class CsvLogger:
     # read the headers
     with open(self._filename, 'r', newline='') as f:
       dictreader = csv.DictReader(f)
-      fieldnames = list(dictreader.fieldnames)
+      if dictreader.fieldnames is None:
+        fieldnames = []
+      else:
+        fieldnames = list(dictreader.fieldnames)
 
     with open(self._filename, 'a', newline='') as f:
       missing_fields = set(data.keys()) - set(fieldnames)

--- a/csv_logger.py
+++ b/csv_logger.py
@@ -1,0 +1,35 @@
+import csv
+import os
+from typing import List, Dict
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class CsvLogger:
+  """Logger that appends structured data to a CSV file. Creates one if it doesn't exist.
+  Closes the CSV between append operations, and reads in headers each time.
+  If data doesn't have a header in the CSV, that cell is discarded and a log warning generated."""
+  def __init__(self, filename: str, default_headers: List[str]):
+    self._filename = filename
+    self._default_headers = default_headers
+
+  def log(self, data: Dict[str, str]):
+    if not os.path.exists(self._filename):
+      logger.info(f"creating new file {self._filename}")
+      with open(self._filename, 'a', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(self._default_headers)
+
+    # read the headers
+    with open(self._filename, 'r', newline='') as f:
+      dictreader = csv.DictReader(f)
+      fieldnames = list(dictreader.fieldnames)
+
+    with open(self._filename, 'a', newline='') as f:
+      missing_fields = set(data.keys()) - set(fieldnames)
+      if missing_fields:
+        logger.warn(f"missing fields in file: {missing_fields}")
+      dictwriter = csv.DictWriter(f, fieldnames=fieldnames, extrasaction='ignore')
+      dictwriter.writerow(data)

--- a/test/test_meta.csv
+++ b/test/test_meta.csv
@@ -1,3 +1,0 @@
-timestamp,mac,vbat,fwVer,boot,rst,part,rssi,lastDisplayTime
-1719817200.0,abcd,3900,5,,,,,
-1719838800.0,abcd,3850,5,,,,,

--- a/test/test_meta.csv
+++ b/test/test_meta.csv
@@ -1,0 +1,3 @@
+timestamp,mac,vbat,fwVer,boot,rst,part,rssi,lastDisplayTime
+1719817200.0,abcd,3900,5,,,,,
+1719838800.0,abcd,3850,5,,,,,

--- a/test_csvlogger.py
+++ b/test_csvlogger.py
@@ -41,3 +41,11 @@ class CsvLoggerTestCase(unittest.TestCase):
     logger.log({"a": "4", "d": "5", "c": "6"})
     with open(self.TEST_FILE, 'r') as f:
       self.assertEqual(f.read(), "a,b,c\n1,2,3\n4,,6\n")
+
+  def test_read(self):
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "c"])
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    with open(self.TEST_FILE, 'w') as f:
+      f.write("a,b,c\n1,2,3\n")
+
+    assert logger.read() == "a,b,c\n1,2,3\n"

--- a/test_csvlogger.py
+++ b/test_csvlogger.py
@@ -1,0 +1,43 @@
+import os.path
+import unittest
+
+from csv_logger import CsvLogger
+
+
+class CsvLoggerTestCase(unittest.TestCase):
+  TEST_DIR = "test"
+  TEST_FILE = f"{TEST_DIR}/test.csv"
+
+  def test_create(self):
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    if os.path.isfile(self.TEST_FILE):
+      os.remove(self.TEST_FILE)
+
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "c"])
+    logger.log({"a": "1", "b": "2", "c": "3"})
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c\n1,2,3\n")
+
+  def test_append(self):
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "c"])
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    with open(self.TEST_FILE, 'w') as f:
+      f.write("a,b,c\n1,2,3\n")
+
+    logger.log({"c": "4", "a": "5", "b": "6"})
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c\n1,2,3\n5,6,4\n")
+
+    logger.log({"b": "7", "c": "8", "a": "9"})
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c\n1,2,3\n5,6,4\n9,7,8\n")
+
+  def test_extrafield(self):
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "c"])
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    with open(self.TEST_FILE, 'w') as f:
+      f.write("a,b,c\n1,2,3\n")
+
+    logger.log({"a": "4", "d": "5", "c": "6"})
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c\n1,2,3\n4,,6\n")

--- a/test_csvlogger.py
+++ b/test_csvlogger.py
@@ -48,4 +48,12 @@ class CsvLoggerTestCase(unittest.TestCase):
     with open(self.TEST_FILE, 'w') as f:
       f.write("a,b,c\n1,2,3\n")
 
-    assert logger.read() == "a,b,c\n1,2,3\n"
+    self.assertEqual(logger.read(), "a,b,c\n1,2,3\n")
+
+  def test_read_empty(self):
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "c"])
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    if os.path.isfile(self.TEST_FILE):
+      os.remove(self.TEST_FILE)
+
+    self.assertEqual(logger.read(), "")

--- a/test_eastereggs.py
+++ b/test_eastereggs.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 app.app.testing = True
 
 
-devices = app.DeviceMap({
+config = app.ServerConfig(devices={
   '': app.DeviceRecord(
     title="TESLA ROOM",
     ical_url="TestCalendar.ics",
@@ -21,7 +21,7 @@ devices = app.DeviceMap({
 class EasterEggTestCase(unittest.TestCase):
   def test_image(self):
     with (patch('app.datetime') as mock_datetime,
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(labelcore.SvgTemplate, 'apply_instance') as apply_instance_mock,
           app.app.test_client() as client):
@@ -46,7 +46,7 @@ class EasterEggTestCase(unittest.TestCase):
   def test_meta(self):
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       # check board games night duck gets scheduled

--- a/test_eastereggs.py
+++ b/test_eastereggs.py
@@ -2,7 +2,7 @@ import unittest
 import app
 from test_common import test_get_cached_ical
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import labelcore
 import xml.etree.ElementTree as ET
 
@@ -45,6 +45,7 @@ class EasterEggTestCase(unittest.TestCase):
 
   def test_meta(self):
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):

--- a/test_image.py
+++ b/test_image.py
@@ -9,7 +9,7 @@ app.app.testing = True
 
 # test all the templates to make sure they all work
 kAllTemplates = ['template_750c.svg', 'template_1330c.svg', 'template_1330c_mininext.svg']
-devices = app.DeviceMap({
+config = app.ServerConfig(devices={
   filename: app.DeviceRecord(
     title="TestCalendar",
     ical_url="TestCalendar.ics",
@@ -22,7 +22,7 @@ devices = app.DeviceMap({
 class ImageTestCase(unittest.TestCase):
   def test_image_inuse(self):
     with (patch('app.datetime') as mock_datetime,
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       mock_datetime.now.return_value = datetime(2024, 7, 1, 16, 10, 0).astimezone(app.kTimezone)
@@ -36,7 +36,7 @@ class ImageTestCase(unittest.TestCase):
 
   def test_image_empty(self):
     with (patch('app.datetime') as mock_datetime,
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       mock_datetime.now.return_value = datetime(2024, 7, 1, 15, 0, 0).astimezone(app.kTimezone)

--- a/test_meta_log.py
+++ b/test_meta_log.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+import app
+from csv_logger import CsvLogger
+from test_common import test_get_cached_ical
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+app.app.testing = True
+
+
+class MetaLoggingTestCase(unittest.TestCase):
+  TEST_DIR = "test"
+  TEST_FILE = f"{TEST_DIR}/test_meta.csv"
+
+  def test_log(self):
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    if os.path.isfile(self.TEST_FILE):
+      os.remove(self.TEST_FILE)
+
+    # note, testing of CsvLogger edge cases in its own dedicated test
+    devices = app.DeviceMap({
+      'abcd': app.DeviceRecord(
+        title="",
+        ical_url="TestCalendar.ics",
+        template_filename="",
+      ),
+    })
+    with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', CsvLogger(self.TEST_FILE, app.meta_csv._default_headers)),
+          patch.object(app, 'devices', devices),
+          patch.object(app, 'get_cached_ical', test_get_cached_ical),
+          app.app.test_client() as client):
+      mock_datetime.now.return_value = datetime(2024, 7, 1, 0, 0, 0).astimezone(app.kTimezone)
+      client.get('/meta?mac=abcd&fwVer=5&vbat=3900')
+
+      mock_datetime.now.return_value = datetime(2024, 7, 1, 6, 0, 0).astimezone(app.kTimezone)
+      client.get('/meta?mac=abcd&fwVer=5&vbat=3850')
+
+      with open(self.TEST_FILE, 'r') as f:
+        self.assertEqual(f.read(), """timestamp,mac,vbat,fwVer,boot,rst,part,rssi,lastDisplayTime
+1719817200.0,abcd,3900,5,,,,,
+1719838800.0,abcd,3850,5,,,,,
+""")

--- a/test_meta_log.py
+++ b/test_meta_log.py
@@ -4,7 +4,7 @@ import app
 from csv_logger import CsvLogger
 from test_common import test_get_cached_ical
 from datetime import datetime
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 app.app.testing = True
 

--- a/test_meta_log.py
+++ b/test_meta_log.py
@@ -19,7 +19,7 @@ class MetaLoggingTestCase(unittest.TestCase):
       os.remove(self.TEST_FILE)
 
     # note, testing of CsvLogger edge cases in its own dedicated test
-    devices = app.DeviceMap({
+    config = app.ServerConfig(devices={
       'abcd': app.DeviceRecord(
         title="",
         ical_url="TestCalendar.ics",
@@ -28,7 +28,7 @@ class MetaLoggingTestCase(unittest.TestCase):
     })
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', CsvLogger(self.TEST_FILE, app.meta_csv._default_headers)),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       mock_datetime.now.return_value = datetime(2024, 7, 1, 0, 0, 0).astimezone(app.kTimezone)

--- a/test_meta_ota.py
+++ b/test_meta_ota.py
@@ -9,7 +9,7 @@ app.app.testing = True
 
 class MetaOtaTestCase(unittest.TestCase):
   def test_ota_empty(self):
-    devices = app.DeviceMap({
+    config = app.ServerConfig(devices={
       '': app.DeviceRecord(
         title="",
         ical_url="TestCalendar.ics",
@@ -18,7 +18,7 @@ class MetaOtaTestCase(unittest.TestCase):
     })
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
           app.app.test_client() as client):
@@ -31,7 +31,7 @@ class MetaOtaTestCase(unittest.TestCase):
       self.assertEqual(response.json['ota'], False)
 
   def test_ota(self):
-    devices = app.DeviceMap({
+    config = app.ServerConfig(devices={
       '': app.DeviceRecord(
         title="",
         ical_url="TestCalendar.ics",
@@ -42,7 +42,7 @@ class MetaOtaTestCase(unittest.TestCase):
     })
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
           app.app.test_client() as client):
@@ -64,7 +64,7 @@ class MetaOtaTestCase(unittest.TestCase):
       self.assertEqual(response.data, b"this is real firmware data, I swear")
 
   def test_ota_after(self):
-    devices = app.DeviceMap({
+    config = app.ServerConfig(devices={
       '': app.DeviceRecord(
         title="",
         ical_url="TestCalendar.ics",
@@ -76,7 +76,7 @@ class MetaOtaTestCase(unittest.TestCase):
     })
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
           app.app.test_client() as client):
@@ -89,7 +89,7 @@ class MetaOtaTestCase(unittest.TestCase):
       self.assertEqual(response.json['ota'], True)
 
   def test_ota_antiretry(self):
-    devices = app.DeviceMap({
+    config = app.ServerConfig(devices={
       '': app.DeviceRecord(
         title="",
         ical_url="TestCalendar.ics",
@@ -100,7 +100,7 @@ class MetaOtaTestCase(unittest.TestCase):
     })
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
           app.app.test_client() as client):

--- a/test_meta_ota.py
+++ b/test_meta_ota.py
@@ -2,7 +2,7 @@ import unittest
 import app
 from test_common import test_get_cached_ical
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 app.app.testing = True
 
@@ -17,6 +17,7 @@ class MetaOtaTestCase(unittest.TestCase):
       ),
     })
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
@@ -40,6 +41,7 @@ class MetaOtaTestCase(unittest.TestCase):
       ),
     })
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
@@ -73,6 +75,7 @@ class MetaOtaTestCase(unittest.TestCase):
       ),
     })
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records
@@ -96,6 +99,7 @@ class MetaOtaTestCase(unittest.TestCase):
       ),
     })
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           patch.object(app, 'ota_done_devices', set()),  # clear OTA records

--- a/test_meta_sched.py
+++ b/test_meta_sched.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 app.app.testing = True
 
 
-devices = app.DeviceMap({
+config = app.ServerConfig(devices={
   '': app.DeviceRecord(
     title="TestCalendar",
     ical_url="TestCalendar.ics",
@@ -20,7 +20,7 @@ class MetaScheduleTestCase(unittest.TestCase):
   def test_nextevent(self):
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       # before 8am event

--- a/test_meta_sched.py
+++ b/test_meta_sched.py
@@ -2,7 +2,7 @@ import unittest
 import app
 from test_common import test_get_cached_ical
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 app.app.testing = True
 
@@ -19,6 +19,7 @@ devices = app.DeviceMap({
 class MetaScheduleTestCase(unittest.TestCase):
   def test_nextevent(self):
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):

--- a/test_multidevice.py
+++ b/test_multidevice.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, MagicMock
 app.app.testing = True
 
 
-devices = app.DeviceMap({
+config = app.ServerConfig(devices={
   'a1b1': app.DeviceRecord(
     title="TestCalendar",
     ical_url="TestCalendar.ics",
@@ -24,7 +24,7 @@ class MultiDeviceTestCase(unittest.TestCase):
   def test_multidevice(self):
     with (patch('app.datetime') as mock_datetime,
           patch.object(app, 'meta_csv', MagicMock()),
-          patch.object(app, 'devices', devices),
+          patch.object(app, 'config', config),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):
       mock_datetime.now.return_value = datetime(2024, 7, 1, 8, 0, 0).astimezone(app.kTimezone)

--- a/test_multidevice.py
+++ b/test_multidevice.py
@@ -2,7 +2,7 @@ import unittest
 import app
 from test_common import test_get_cached_ical
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 app.app.testing = True
 
@@ -23,6 +23,7 @@ devices = app.DeviceMap({
 class MultiDeviceTestCase(unittest.TestCase):
   def test_multidevice(self):
     with (patch('app.datetime') as mock_datetime,
+          patch.object(app, 'meta_csv', MagicMock()),
           patch.object(app, 'devices', devices),
           patch.object(app, 'get_cached_ical', test_get_cached_ical),
           app.app.test_client() as client):


### PR DESCRIPTION
Gets logged to a `persist/` folder and includes data like battery voltage and reset status. The CSV can be obtained through the web interface with a password, if the configuration is set up for it.

Also changes the configuration infrastructure so that devices is just an entry, instead of the root, and can coexist with other fields like password. Old style config will still load.