### PR TITLE
CSV logger shouldn't delete fields

### DIFF
--- a/csv_logger.py
+++ b/csv_logger.py
@@ -34,7 +34,7 @@ class CsvLogger:
 
       logger.info(f"rewriting {self._filename} with additional headers: {missing_fields}")
       with open(self._filename, 'w', newline='') as f:
-        dictwriter = csv.DictWriter(f, fieldnames=list(dictreader.fieldnames) + missing_fields, extrasaction='ignore')
+        dictwriter = csv.DictWriter(f, fieldnames=list(dictreader.fieldnames) + missing_fields, extrasaction='raise')
         dictwriter.writeheader()
         for row in rows:
           dictwriter.writerow(row)

--- a/csv_logger.py
+++ b/csv_logger.py
@@ -34,7 +34,7 @@ class CsvLogger:
 
       logger.info(f"rewriting {self._filename} with additional headers: {missing_fields}")
       with open(self._filename, 'w', newline='') as f:
-        dictwriter = csv.DictWriter(f, fieldnames=self._default_headers, extrasaction='ignore')
+        dictwriter = csv.DictWriter(f, fieldnames=list(dictreader.fieldnames) + missing_fields, extrasaction='ignore')
         dictwriter.writeheader()
         for row in rows:
           dictwriter.writerow(row)

--- a/test_csvlogger.py
+++ b/test_csvlogger.py
@@ -40,11 +40,32 @@ class CsvLoggerTestCase(unittest.TestCase):
     logger = CsvLogger(self.TEST_FILE, ["a", "b", "d", "c"])
     logger.update_headers()
     with open(self.TEST_FILE, 'r') as f:
-      self.assertEqual(f.read(), "a,b,d,c\n1,2,,3\n")
+      self.assertEqual(f.read(), "a,b,c,d\n1,2,3,\n")
 
     logger.log({"c": "4", "a": "5", "b": "6", "d": "7"})
     with open(self.TEST_FILE, 'r') as f:
-      self.assertEqual(f.read(), "a,b,d,c\n1,2,,3\n5,6,7,4\n")
+      self.assertEqual(f.read(), "a,b,c,d\n1,2,3,\n5,6,4,7\n")
+
+    logger.update_headers()
+
+  def test_update_headers_nodelete(self):
+    os.makedirs(self.TEST_DIR, exist_ok=True)
+    with open(self.TEST_FILE, 'w') as f:
+      f.write("a,b,c\n1,2,3\n")
+
+    logger = CsvLogger(self.TEST_FILE, ["a", "b"])
+    logger.update_headers()
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c\n1,2,3\n")
+
+    logger = CsvLogger(self.TEST_FILE, ["a", "b", "d"])
+    logger.update_headers()
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c,d\n1,2,3,\n")
+
+    logger.log({"a": "5", "b": "6"})
+    with open(self.TEST_FILE, 'r') as f:
+      self.assertEqual(f.read(), "a,b,c,d\n1,2,3,\n5,6,,\n")
 
     logger.update_headers()
 


### PR DESCRIPTION
Extra fields now added to the end, and discarded data should now raise an error